### PR TITLE
Fix non-primary monitor screenshot

### DIFF
--- a/Widget.cpp
+++ b/Widget.cpp
@@ -10,9 +10,8 @@
 Widget::Widget()
 {
     connect(new QShortcut(Qt::Key_Escape, this), &QShortcut::activated, this, &Widget::close);
-    QScreen *screen = windowHandle() ? windowHandle()->screen() : QGuiApplication::primaryScreen();
 
-    m_screenshot = screen->grabWindow(0);
+    m_screenshot = qApp->screenAt(QCursor::pos())->grabWindow(0);
 
     showFullScreen();
     setCursor(Qt::CrossCursor);


### PR DESCRIPTION
On my setup (Ubuntu 20.04, i3, x) `windowHandle()` seems to always return a `nullptr`. As a result, the `QGuiApplication::primaryScreen();` fallback is always used. 

(On a sidenote, since my primary monitor is horizontal and my secondary vertical, the screenshot is taken from the primary but the fullscreen widget is shown on the secondary when I try to screen-grab the secondary. That looks really weird because it gets squeezed to fit the vertical resolution and of-course stops me from taking screenshots from my secondary monitor)

I'm not sure what's the reason for `windowHandle()` returning `nullptr` and whether it happens only on my machine or not, but I thought that it might be better to simply use the screen the cursor is currently in for the screengrab. That works alright on my setup.

